### PR TITLE
Feature/selenide update (#124)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,11 +53,11 @@ targetCompatibility = 1.8
 
 project.ext {
     cucumberVersion = '2.4.0'
-    selenideVersion = '4.11.4'
+    selenideVersion = '5.1.0'
 }
 
 dependencies {
-    compile group: 'org.hamcrest', name: 'hamcrest-all', version: '1.3'
+    compile group: 'org.hamcrest', name: 'hamcrest-library', version: '2.1'
     compile group: 'org.codehaus.groovy', name: 'groovy', version: '2.4.8'
     compile group: 'org.reflections', name: 'reflections', version: '0.9.10'
     compile group: 'junit', name: 'junit', version: '4.12'

--- a/src/main/java/ru/alfabank/alfatest/cucumber/api/AkitaEnvironment.java
+++ b/src/main/java/ru/alfabank/alfatest/cucumber/api/AkitaEnvironment.java
@@ -16,6 +16,7 @@
 package ru.alfabank.alfatest.cucumber.api;
 
 import cucumber.api.Scenario;
+import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import ru.alfabank.alfatest.cucumber.ScopedVariables;
 import ru.alfabank.alfatest.cucumber.annotations.Name;
@@ -56,6 +57,7 @@ public class AkitaEnvironment {
      * добавляя ссылки на эти классы в поле "pages"
      */
     @SuppressWarnings("unchecked")
+    @SneakyThrows
     private void initPages() {
         new AnnotationScanner().getClassesAnnotatedWith(Name.class)
                 .stream()

--- a/src/main/java/ru/alfabank/alfatest/cucumber/api/AkitaPage.java
+++ b/src/main/java/ru/alfabank/alfatest/cucumber/api/AkitaPage.java
@@ -44,6 +44,10 @@ public abstract class AkitaPage extends ElementsContainer {
      */
     private static final String WAITING_APPEAR_TIMEOUT_IN_MILLISECONDS = "8000";
 
+    public AkitaPage() {
+        super();
+    }
+
     /**
      * Получение блока со страницы по имени (аннотированного "Name")
      */
@@ -192,7 +196,7 @@ public abstract class AkitaPage extends ElementsContainer {
                 .filter(f -> f.getDeclaredAnnotation(Optional.class) == null)
                 .forEach(f -> {
                     if (AkitaPage.class.isAssignableFrom(f.getType())){
-                        AkitaPage akitaPage = AkitaScenario.getInstance().getPage((Class<? extends AkitaPage>)f.getType());
+                        AkitaPage akitaPage = AkitaScenario.getInstance().getPage((Class<? extends AkitaPage>)f.getType()).initialize();
                         func.accept(akitaPage);
                     }
                 });

--- a/src/main/java/ru/alfabank/alfatest/cucumber/api/AkitaScenario.java
+++ b/src/main/java/ru/alfabank/alfatest/cucumber/api/AkitaScenario.java
@@ -148,8 +148,8 @@ public final class AkitaScenario {
      * @param clazz                   - класс страницы, которую необходимо получить
      * @param checkIfElementsAppeared - флаг, определяющий проверку отображения элементов на странице
      */
-    public <T extends AkitaPage> T getPage(Class<T> clazz, boolean checkIfElementsAppeared) {
-        return Pages.getPage(clazz, checkIfElementsAppeared);
+    public <T extends AkitaPage> AkitaPage getPage(Class<T> clazz, boolean checkIfElementsAppeared) {
+        return Pages.getPage(clazz, checkIfElementsAppeared).initialize();
     }
 
     /**

--- a/src/main/java/ru/alfabank/tests/core/helpers/PropertyLoader.java
+++ b/src/main/java/ru/alfabank/tests/core/helpers/PropertyLoader.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package ru.alfabank.tests.core.helpers;
 
 import com.google.common.base.Strings;

--- a/src/test/java/ru/alfabank/other/AkitaEnvironmentTest.java
+++ b/src/test/java/ru/alfabank/other/AkitaEnvironmentTest.java
@@ -15,11 +15,18 @@
  */
 package ru.alfabank.other;
 
+import cucumber.api.Scenario;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import ru.alfabank.AkitaPageMock;
+import ru.alfabank.StubScenario;
 import ru.alfabank.alfatest.cucumber.api.AkitaEnvironment;
+import ru.alfabank.alfatest.cucumber.api.AkitaScenario;
+import ru.alfabank.steps.DefaultSteps;
 
+import java.io.File;
+
+import static com.codeborne.selenide.WebDriverRunner.getWebDriver;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
@@ -28,11 +35,21 @@ public class AkitaEnvironmentTest {
 
     @BeforeClass
     public static void prepare() {
+
         env = new AkitaEnvironment();
+        AkitaScenario akitaScenario = AkitaScenario.getInstance();
+        DefaultSteps ds = new DefaultSteps();
+        Scenario scenario = new StubScenario();
+        akitaScenario.setEnvironment(new AkitaEnvironment(scenario));
+        String inputFilePath = "src/test/resources/AkitaPageMock.html";
+        String url = new File(inputFilePath).getAbsolutePath();
+        akitaScenario.setVar("Page", "file://" + url);
+        ds.goToSelectedPageByLink("AkitaPageMock", akitaScenario.getVar("Page").toString());
     }
 
     @Test
     public void initPagesTest() {
+        getWebDriver().navigate();
         assertThat(env.getPage("AkitaPageMock"), is(notNullValue()));
     }
 

--- a/src/test/java/ru/alfabank/other/AkitaPageTest.java
+++ b/src/test/java/ru/alfabank/other/AkitaPageTest.java
@@ -52,8 +52,8 @@ public class AkitaPageTest {
         String inputFilePath = "src/test/resources/AkitaPageMock.html";
         String url = new File(inputFilePath).getAbsolutePath();
         akitaScenario.setVar("Page", "file://" + url);
-        page = akitaScenario.getEnvironment().getPage("AkitaPageMock");
         ds.goToSelectedPageByLink("AkitaPageMock", akitaScenario.getVar("Page").toString());
+        page = akitaScenario.getEnvironment().getPage("AkitaPageMock");
     }
 
     @AfterClass

--- a/src/test/java/ru/alfabank/other/AkitaScenarioTest.java
+++ b/src/test/java/ru/alfabank/other/AkitaScenarioTest.java
@@ -23,7 +23,11 @@ import ru.alfabank.StubScenario;
 import ru.alfabank.alfatest.cucumber.api.AkitaEnvironment;
 import ru.alfabank.alfatest.cucumber.api.AkitaPage;
 import ru.alfabank.alfatest.cucumber.api.AkitaScenario;
+import ru.alfabank.steps.DefaultSteps;
 
+import java.io.File;
+
+import static com.codeborne.selenide.Selenide.open;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.mockito.Mockito.mock;
@@ -46,7 +50,6 @@ public class AkitaScenarioTest {
         Scenario scenario = new StubScenario();
         AkitaPage akitaPageMock = mock(AkitaPage.class);
         akitaScenario.setEnvironment(new AkitaEnvironment(scenario));
-        akitaScenario.getPages().put("Title", akitaPageMock);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -66,7 +69,17 @@ public class AkitaScenarioTest {
 
     @Test
     public void putGetPagesPositive() {
-        assertThat(akitaScenario.getPage("Title"), is(notNullValue()));
+        AkitaScenario akitaScenario = AkitaScenario.getInstance();
+        DefaultSteps ds = new DefaultSteps();
+        Scenario scenario = new StubScenario();
+        akitaScenario.setEnvironment(new AkitaEnvironment(scenario));
+        String inputFilePath = "src/test/resources/AkitaPageMock.html";
+        String url = new File(inputFilePath).getAbsolutePath();
+        akitaScenario.setVar("Page", "file://" + url);
+        ds.goToSelectedPageByLink("AkitaPageMock", akitaScenario.getVar("Page").toString());
+        akitaScenario.setCurrentPage(akitaScenario.getPage("AkitaPageMock"));
+        assertThat(akitaScenario.getPage("AkitaPageMock"), is(notNullValue()));
+        close();
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -88,8 +101,17 @@ public class AkitaScenarioTest {
 
     @Test
     public void getCurrentPagePositive() {
-        akitaScenario.setCurrentPage(akitaScenario.getPage("Title"));
+        AkitaScenario akitaScenario = AkitaScenario.getInstance();
+        DefaultSteps ds = new DefaultSteps();
+        Scenario scenario = new StubScenario();
+        akitaScenario.setEnvironment(new AkitaEnvironment(scenario));
+        String inputFilePath = "src/test/resources/AkitaPageMock.html";
+        String url = new File(inputFilePath).getAbsolutePath();
+        akitaScenario.setVar("Page", "file://" + url);
+        ds.goToSelectedPageByLink("AkitaPageMock", akitaScenario.getVar("Page").toString());
+        akitaScenario.setCurrentPage(akitaScenario.getPage("AkitaPageMock"));
         assertThat(akitaScenario.getCurrentPage(), is(notNullValue()));
+        close();
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/src/test/java/ru/alfabank/other/PagesTest.java
+++ b/src/test/java/ru/alfabank/other/PagesTest.java
@@ -15,11 +15,18 @@
  */
 package ru.alfabank.other;
 
+import cucumber.api.Scenario;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import ru.alfabank.AkitaPageMock;
+import ru.alfabank.StubScenario;
+import ru.alfabank.alfatest.cucumber.api.AkitaEnvironment;
 import ru.alfabank.alfatest.cucumber.api.AkitaPage;
+import ru.alfabank.alfatest.cucumber.api.AkitaScenario;
 import ru.alfabank.alfatest.cucumber.api.Pages;
+import ru.alfabank.steps.DefaultSteps;
+
+import java.io.File;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
@@ -32,6 +39,15 @@ public class PagesTest {
     public static void init() {
         pages = new Pages();
         akitaPageMock = new AkitaPageMock();
+
+        AkitaScenario akitaScenario = AkitaScenario.getInstance();
+        DefaultSteps ds = new DefaultSteps();
+        Scenario scenario = new StubScenario();
+        akitaScenario.setEnvironment(new AkitaEnvironment(scenario));
+        String inputFilePath = "src/test/resources/AkitaPageMock.html";
+        String url = new File(inputFilePath).getAbsolutePath();
+        akitaScenario.setVar("Page", "file://" + url);
+        ds.goToSelectedPageByLink("AkitaPageMock", akitaScenario.getVar("Page").toString());
     }
 
     @Test
@@ -58,8 +74,8 @@ public class PagesTest {
         pages.put("Test", nullPage);
     }
 
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void getNegative() {
-        assertThat(pages.get("WRONG_KEY"), is(nullValue()));
+        pages.get("WRONG_KEY_TO_GET_PAGE");
     }
 }


### PR DESCRIPTION
update to selenide 5.1.0 #119 
Changed initialization order. Now cast to Selenide.page() and initialize() calls when trying to get page from map with available by @Name pages. Because Selenide doesn’t open a browser automatically and the right way is to open a browser first (by calling open(url)) and then search elements https://ru.selenide.org/2018/10/10/selenide-5.0.0/
updated hamcrest to 2.1